### PR TITLE
Remove /.idea out of .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ Homestead.json
 .env
 composer.lock
 /.vagrant
-/.idea


### PR DESCRIPTION
`/.idea` is user-specific and should not appear in a project `.gitignore`. Consider adding it to the user global `.gitignore` instead.
